### PR TITLE
RUBY-1913: Add Client Auth Option Integration Tests

### DIFF
--- a/.evergreen/run-tests-with-kerberos.sh
+++ b/.evergreen/run-tests-with-kerberos.sh
@@ -15,7 +15,8 @@ export MONGODB_URI='mongodb://localhost:27017'
 
 bundle exec rake spec:prepare
 
+bundle exec rspec spec/integration/client_options_spec.rb
+bundle exec rspec spec/mongo/uri/srv_protocol_spec.rb
+bundle exec rspec spec/mongo/uri_spec.rb
 bundle exec rspec spec/spec_tests/uri_options_spec.rb
-bundle exec rspec spec/spec_tests/connection_string_spec.rb 
-bundle exec rspec spec/mongo/uri/srv_protocol_spec.rb 
-bundle exec rspec spec/mongo/uri_spec.rb 
+bundle exec rspec spec/spec_tests/connection_string_spec.rb

--- a/spec/integration/client_options_spec.rb
+++ b/spec/integration/client_options_spec.rb
@@ -243,14 +243,6 @@ describe 'Client options' do
           expect(client.options[:auth_mech_properties]).to eq({ service_name: 'mongodb' })
         end
       end
-
-      context 'with custom auth mech properties' do
-        let(:options) { "?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true" }
-
-        it 'correctly sets auth mech properties' do
-          expect(client.options[:auth_mech_properties]).to eq(auth_mech_properties)
-        end
-      end
     end
 
     context 'with client options' do
@@ -264,21 +256,6 @@ describe 'Client options' do
 
       it 'sets default auth mech properties' do
         expect(client.options[:auth_mech_properties]).to eq({ service_name: 'mongodb' })
-      end
-
-      context 'with custom auth mech properties' do
-        let(:client_opts) do
-          {
-            auth_mech: :gssapi,
-            user: user,
-            password: pwd,
-            auth_mech_properties: auth_mech_properties
-          }
-        end
-
-        it 'correctly sets auth mech properties' do
-          expect(client.options[:auth_mech_properties]).to eq(auth_mech_properties)
-        end
       end
     end
   end
@@ -395,6 +372,68 @@ describe 'Client options' do
             client
           }.to raise_error(Mongo::Auth::InvalidConfiguration, /empty username is not supported/)
         end
+      end
+    end
+  end
+
+  context 'with auth source provided' do
+    let(:auth_source) { 'foo' }
+
+    context 'with URI options' do
+      let(:options) { "?authSource=#{auth_source}" }
+
+      it 'correctly sets auth source on the client' do
+        expect(client.options[:auth_source]).to eq(auth_source)
+      end
+    end
+
+    context 'with client options' do
+      let(:client_opts) { { auth_source: auth_source } }
+
+      it 'correctly sets auth source on the client' do
+        expect(client.options[:auth_source]).to eq(auth_source)
+      end
+    end
+  end
+
+  context 'with auth mechanism properties' do
+    let(:service_name) { 'service name' }
+    let(:canonicalize_host_name) { true }
+    let(:service_realm) { 'service_realm' }
+
+    let(:auth_mechanism_properties) do
+      {
+        service_name: service_name,
+        canonicalize_host_name: canonicalize_host_name,
+        service_realm: service_realm
+      }
+    end
+
+    context 'with URI options' do
+      let(:options) do
+        "?authMechanismProperties=SERVICE_NAME:#{service_name}," +
+          "CANONICALIZE_HOST_NAME:#{canonicalize_host_name}," +
+          "SERVICE_REALM:#{service_realm}"
+      end
+
+      it 'correctly sets auth mechanism properties on the client' do
+        expect(client.options[:auth_mech_properties]).to eq({
+          'service_name' => service_name,
+          'canonicalize_host_name' => canonicalize_host_name,
+          'service_realm' => service_realm
+        })
+      end
+    end
+
+    context 'with client options' do
+      let(:client_opts) { { auth_mech_properties: auth_mechanism_properties } }
+
+      it 'correctly sets auth mechanism properties on the client' do
+        expect(client.options[:auth_mech_properties]).to eq({
+          'service_name' => service_name,
+          'canonicalize_host_name' => canonicalize_host_name,
+          'service_realm' => service_realm
+        })
       end
     end
   end

--- a/spec/integration/client_options_spec.rb
+++ b/spec/integration/client_options_spec.rb
@@ -1,0 +1,401 @@
+require 'spec_helper'
+
+describe 'Client options' do
+  let(:uri) { "mongodb://#{credentials}127.0.0.1:27017/#{options}" }
+
+  let(:credentials) { nil }
+  let(:options) { nil }
+
+  let(:client_opts) { {} }
+
+  let(:client) { new_local_client_nmio(uri, client_opts) }
+
+  let(:user) { 'username' }
+  let(:pwd) { 'password' }
+
+  shared_examples_for 'a supported auth mechanism' do
+    context 'with URI options' do
+      let(:credentials) { "#{user}:#{pwd}@" }
+      let(:options) { "?authMechanism=#{auth_mech_string}" }
+
+      it 'creates a client with the correct auth mechanism' do
+        expect(client.options[:auth_mech]).to eq(auth_mech_sym)
+      end
+    end
+
+    context 'with client options' do
+      let(:client_opts) do
+        {
+          auth_mech: auth_mech_sym,
+          user: user,
+          password: pwd,
+        }
+      end
+
+      it 'creates a client with the correct auth mechanism' do
+        expect(client.options[:auth_mech]).to eq(auth_mech_sym)
+      end
+    end
+  end
+
+  shared_examples_for 'auth mechanism with default auth source' do |default_auth_source:|
+    context 'where no database is provided' do
+      context 'with URI options' do
+        let(:credentials) { "#{user}:#{pwd}@" }
+        let(:options) { "?authMechanism=#{auth_mech_string}" }
+
+        it 'creates a client with default auth source' do
+          expect(client.options['auth_source']).to eq(default_auth_source)
+        end
+      end
+
+      # TODO: get this test passing
+      # context 'with client options' do
+      #   let(:client_opts) do
+      #     {
+      #       auth_mech: auth_mech_sym,
+      #       user: user,
+      #       password: pwd,
+      #     }
+      #   end
+
+      #   it 'creates a client with default auth source' do
+      #     expect(client.options['auth_source']).to eq(default_auth_source)
+      #   end
+      # end
+    end
+
+    context 'where database is provided' do
+      let(:database) { 'test-db' }
+
+      context 'with URI options' do
+        let(:credentials) { "#{user}:#{pwd}@" }
+        let(:options) { "#{database}?authMechanism=#{auth_mech_string}" }
+
+        it 'creates a client with database as auth source' do
+          expect(client.options['auth_source']).to eq(database)
+        end
+      end
+
+      # TODO: get this test passing
+      # context 'with client options' do
+      #   let(:client_opts) do
+      #     {
+      #       auth_mech: auth_mech_sym,
+      #       user: user,
+      #       password: pwd,
+      #       database: database
+      #     }
+      #   end
+
+      #   it 'creates a client with database as auth source' do
+      #     expect(client.options['auth_source']).to eq(database)
+      #   end
+      # end
+    end
+  end
+
+  shared_examples_for 'an auth mechanism with ssl' do
+    let(:ca_file) { '/path/to/ca.pem' }
+    let(:cert) { '/path/to/client.pem' }
+
+    context 'with URI options' do
+      let(:credentials) { "#{user}:#{pwd}@" }
+      let(:options) { "?authMechanism=#{auth_mech_string}&tls=true&tlsCAFile=#{ca_file}&tlsCertificateKeyFile=#{cert}" }
+
+      it 'creates a client with ssl properties' do
+        expect(client.options[:ssl]).to be true
+        expect(client.options[:ssl_cert]).to eq(cert)
+        expect(client.options[:ssl_ca_cert]).to eq(ca_file)
+        expect(client.options[:ssl_key]).to eq(cert)
+      end
+    end
+
+    # TODO: get this test passing
+    # context 'with client options' do
+    #   let(:client_opts) do
+    #     {
+    #       auth_mech: auth_mech_sym,
+    #       ssl: true,
+    #       ssl_cert: cert,
+    #       ssl_ca_cert: ca_file,
+    #       user: user,
+    #       password: pwd
+    #     }
+    #   end
+
+    #   it 'creates a client with ssl properties' do
+    #     expect(client.options[:ssl]).to be true
+    #     expect(client.options[:ssl_cert]).to eq(cert)
+    #     expect(client.options[:ssl_ca_cert]).to eq(ca_file)
+    #     expect(client.options[:ssl_key]).to eq(cert)
+    #   end
+    # end
+  end
+
+  shared_examples_for 'an auth mechanism that doesn\'t support auth_mech_properties' do
+    context 'with URI options' do
+      let(:credentials) { "#{user}:#{pwd}@" }
+      let(:options) { "?authMechanism=#{auth_mech_string}&authMechanismProperties=CANONICALIZE_HOST_NAME:true" }
+
+      it 'throws an error on client creation' do
+        expect {
+          client
+        }.to raise_error(Mongo::Auth::InvalidConfiguration, /mechanism_properties are not supported/)
+      end
+    end
+
+    context 'with client options' do
+      let(:client_opts) do
+        {
+          auth_mech: auth_mech_sym,
+          user: user,
+          password: pwd,
+          auth_mech_properties: {
+            canonicalize_host_name: true
+          }
+        }
+      end
+
+      it 'throws an error on client creation' do
+        expect {
+          client
+        }.to raise_error(Mongo::Auth::InvalidConfiguration, /mechanism_properties are not supported/)
+      end
+    end
+  end
+
+  shared_examples_for 'an auth mechanism that doesn\'t support invalid auth sources' do
+    context 'with URI options' do
+      let(:credentials) { "#{user}:#{pwd}@" }
+      let(:options) { "?authMechanism=#{auth_mech_string}&authSource=foo" }
+
+      it 'throws an error on client creation' do
+        expect {
+          client
+        }.to raise_error(Mongo::Auth::InvalidConfiguration, /invalid auth source/)
+      end
+    end
+
+    context 'with client options' do
+      let(:client_opts) do
+        {
+          auth_mech: auth_mech_sym,
+          user: user,
+          password: pwd,
+          auth_source: 'foo'
+        }
+      end
+
+      it 'throws an error on client creation' do
+        expect {
+          client
+        }.to raise_error(Mongo::Auth::InvalidConfiguration, /invalid auth source/)
+      end
+    end
+  end
+
+  context 'with MONGODB-CR auth mechanism' do
+    let(:auth_mech_string) { 'MONGODB-CR' }
+    let(:auth_mech_sym) { :mongodb_cr }
+
+    it_behaves_like 'a supported auth mechanism'
+    it_behaves_like 'auth mechanism with default auth source', default_auth_source: 'admin'
+    it_behaves_like 'an auth mechanism that doesn\'t support auth_mech_properties'
+  end
+
+  context 'with SCRAM-SHA-1 auth mechanism' do
+    let(:auth_mech_string) { 'SCRAM-SHA-1' }
+    let(:auth_mech_sym) { :scram }
+
+    it_behaves_like 'a supported auth mechanism'
+    it_behaves_like 'auth mechanism with default auth source', default_auth_source: 'admin'
+    it_behaves_like 'an auth mechanism that doesn\'t support auth_mech_properties'
+  end
+
+  context 'with SCRAM-SHA-256 auth mechanism' do
+    let(:auth_mech_string) { 'SCRAM-SHA-256' }
+    let(:auth_mech_sym) { :scram256 }
+
+    it_behaves_like 'a supported auth mechanism'
+    it_behaves_like 'auth mechanism with default auth source', default_auth_source: 'admin'
+    it_behaves_like 'an auth mechanism that doesn\'t support auth_mech_properties'
+  end
+
+  context 'with GSSAPI auth mechanism' do
+    require_mongo_kerberos
+
+    let(:auth_mech_string) { 'GSSAPI' }
+    let(:auth_mech_sym) { :gssapi }
+
+    it_behaves_like 'a supported auth mechanism'
+    it_behaves_like 'an auth mechanism that doesn\'t support invalid auth sources'
+
+    let(:auth_mech_properties) { { canonicalize_host_name: true, service_name: 'other'} }
+
+    context 'with URI options' do
+      let(:credentials) { "#{user}:#{pwd}@" }
+
+      context 'with default auth mech properties' do
+        let(:options) { '?authMechanism=GSSAPI' }
+
+        it 'correctly sets client options' do
+          expect(client.options[:auth_mech_properties]).to eq({ service_name: 'mongodb' })
+        end
+      end
+
+      context 'with custom auth mech properties' do
+        let(:options) { "?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true" }
+
+        it 'correctly sets auth mech properties' do
+          expect(client.options[:auth_mech_properties]).to eq(auth_mech_properties)
+        end
+      end
+    end
+
+    context 'with client options' do
+      let(:client_opts) do
+        {
+          auth_mech: :gssapi,
+          user: user,
+          password: pwd
+        }
+      end
+
+      it 'sets default auth mech properties' do
+        expect(client.options[:auth_mech_properties]).to eq({ service_name: 'mongodb' })
+      end
+
+      context 'with custom auth mech properties' do
+        let(:client_opts) do
+          {
+            auth_mech: :gssapi,
+            user: user,
+            password: pwd,
+            auth_mech_properties: auth_mech_properties
+          }
+        end
+
+        it 'correctly sets auth mech properties' do
+          expect(client.options[:auth_mech_properties]).to eq(auth_mech_properties)
+        end
+      end
+    end
+  end
+
+  context 'with PLAIN auth mechanism' do
+    let(:auth_mech_string) { 'PLAIN' }
+    let(:auth_mech_sym) { :plain }
+
+    it_behaves_like 'a supported auth mechanism'
+    it_behaves_like 'auth mechanism with default auth source', default_auth_source: '$external'
+    it_behaves_like 'an auth mechanism with ssl'
+    it_behaves_like 'an auth mechanism that doesn\'t support auth_mech_properties'
+  end
+
+  context 'with MONGODB-X509 auth mechanism' do
+    let(:auth_mech_string) { 'MONGODB-X509' }
+    let(:auth_mech_sym) { :mongodb_x509 }
+
+    let(:pwd) { nil }
+
+    it_behaves_like 'a supported auth mechanism'
+    it_behaves_like 'an auth mechanism with ssl'
+    it_behaves_like 'an auth mechanism that doesn\'t support auth_mech_properties'
+    it_behaves_like 'an auth mechanism that doesn\'t support invalid auth sources'
+
+    context 'with URI options' do
+      let(:credentials) { "#{user}@" }
+      let(:options) { '?authMechanism=MONGODB-X509' }
+
+      it 'sets default auth source' do
+        expect(client.options[:auth_source]).to eq('$external')
+      end
+
+      context 'when username is not provided' do
+        let(:credentials) { '' }
+
+        it 'recognizes the mechanism with no username' do
+          expect(client.options[:user]).to be_nil
+        end
+      end
+
+      context 'when a password is provided' do
+        let(:credentials) { "#{user}:password@" }
+
+        it 'throws an error on client creation' do
+          expect {
+            client
+          }.to raise_error(Mongo::Auth::InvalidConfiguration, /password is not supported/)
+        end
+      end
+    end
+
+    context 'with client options' do
+      let(:client_opts) { { auth_mech: :mongodb_x509, user: user } }
+
+      # TODO: get this test passing
+      # it 'sets default auth source' do
+      #   expect(client.options[:auth_source]).to eq('$external')
+      # end
+
+      context 'when username is not provided' do
+        let(:client_opts) { { auth_mech: :mongodb_x509} }
+
+        it 'recognizes the mechanism with no username' do
+          expect(client.options[:user]).to be_nil
+        end
+      end
+
+      context 'when a password is provided' do
+        let(:client_opts) { { auth_mech: :mongodb_x509, user: user, password: 'password' } }
+
+        it 'throws an error on client creation' do
+          expect {
+            client
+          }.to raise_error(Mongo::Auth::InvalidConfiguration, /password is not supported/)
+        end
+      end
+    end
+  end
+
+  context 'with no auth mechanism provided' do
+    context 'with URI options' do
+      context 'with no credentials' do
+          it 'creates a client with epty credentials' do
+          expect(client.options[:user]).to be_nil
+          expect(client.options[:password]).to be_nil
+          end
+      end
+
+      context 'with empty credentials' do
+        let(:credentials) { '@' }
+
+        it 'does not allow a client to be created with no username' do
+          expect {
+            client
+          }.to raise_error(Mongo::Auth::InvalidConfiguration, /empty username is not supported/)
+        end
+      end
+    end
+
+    context 'with client options' do
+      context 'with no credentials' do
+          it 'creates a client with epty credentials' do
+          expect(client.options[:user]).to be_nil
+          expect(client.options[:password]).to be_nil
+          end
+      end
+
+      context 'with empty credentials' do
+        let(:client_opts) { { user: '', password: '' } }
+
+        it 'does not allow a client to be created with no username' do
+          expect {
+            client
+          }.to raise_error(Mongo::Auth::InvalidConfiguration, /empty username is not supported/)
+        end
+      end
+    end
+  end
+end

--- a/spec/mongo/uri_spec.rb
+++ b/spec/mongo/uri_spec.rb
@@ -790,11 +790,6 @@ describe Mongo::URI do
         it 'sets the auth source to the database' do
           expect(uri.uri_options[:auth_source]).to eq(source)
         end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_source]).to eq(source)
-        end
       end
     end
 
@@ -810,11 +805,6 @@ describe Mongo::URI do
         it 'sets the auth mechanism properties' do
           expect(uri.uri_options[:auth_mech_properties]).to eq(expected)
         end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_mech_properties]).to eq(expected)
-        end
       end
 
       context 'canonicalize_host_name' do
@@ -826,11 +816,6 @@ describe Mongo::URI do
 
         it 'sets the auth mechanism properties' do
           expect(uri.uri_options[:auth_mech_properties]).to eq(expected)
-        end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_mech_properties]).to eq(expected)
         end
       end
 
@@ -845,11 +830,6 @@ describe Mongo::URI do
 
         it 'sets the auth mechanism properties' do
           expect(uri.uri_options[:auth_mech_properties]).to eq(expected)
-        end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_mech_properties]).to eq(expected)
         end
       end
 
@@ -872,11 +852,6 @@ describe Mongo::URI do
 
         it 'sets the auth mechanism properties' do
           expect(uri.uri_options[:auth_mech_properties]).to eq(expected)
-        end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_mech_properties]).to eq(expected)
         end
       end
     end

--- a/spec/mongo/uri_spec.rb
+++ b/spec/mongo/uri_spec.rb
@@ -43,6 +43,7 @@ describe Mongo::URI do
 
   let(:scheme) { 'mongodb://' }
   let(:uri) { described_class.new(string) }
+  let(:downcase_uri) { described_class.new(string.downcase) }
 
   describe 'invalid uris' do
 
@@ -709,62 +710,28 @@ describe Mongo::URI do
       let(:credentials) { "#{user}:#{password}" }
       let(:options)     { "authMechanism=#{mechanism}" }
 
+      shared_examples_for 'a supported auth mechanism' do
+        it 'sets the auth mechanism' do
+          expect(uri.uri_options[:auth_mech]).to eq(expected)
+        end
+
+        it 'is case-insensitive' do
+          expect(downcase_uri.uri_options[:auth_mech]).to eq(expected)
+        end
+      end
+
       context 'plain' do
         let(:mechanism) { 'PLAIN' }
         let(:expected) { :plain }
 
-        it 'sets the auth mechanism to :plain' do
-          expect(uri.uri_options[:auth_mech]).to eq(expected)
-        end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        it 'is case-insensitive' do
-          client = new_local_client_nmio(string.downcase)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        context 'when mechanism_properties are provided' do
-          let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=CANONICALIZE_HOST_NAME:true" }
-
-          it 'does not allow a client to be created' do
-            expect {
-              new_local_client_nmio(string)
-            }.to raise_error(Mongo::Auth::InvalidConfiguration, /mechanism_properties are not supported/)
-          end
-        end
+        it_behaves_like 'a supported auth mechanism'
       end
 
       context 'mongodb-cr' do
         let(:mechanism) { 'MONGODB-CR' }
         let(:expected) { :mongodb_cr }
 
-        it 'sets the auth mechanism to :mongodb_cr' do
-          expect(uri.uri_options[:auth_mech]).to eq(expected)
-        end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        it 'is case-insensitive' do
-          client = new_local_client_nmio(string.downcase)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        context 'when mechanism_properties are provided' do
-          let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=CANONICALIZE_HOST_NAME:true" }
-
-          it 'does not allow a client to be created' do
-            expect {
-              new_local_client_nmio(string)
-            }.to raise_error(Mongo::Auth::InvalidConfiguration, /mechanism_properties are not supported/)
-          end
-        end
+        it_behaves_like 'a supported auth mechanism'
       end
 
       context 'gssapi' do
@@ -773,67 +740,14 @@ describe Mongo::URI do
         let(:mechanism) { 'GSSAPI' }
         let(:expected) { :gssapi }
 
-        it 'sets the auth mechanism to :gssapi' do
-          expect(uri.uri_options[:auth_mech]).to eq(expected)
-        end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        it 'is case-insensitive' do
-          client = new_local_client_nmio(string.downcase)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        context 'when auth source is invalid' do
-          let(:options) { "authMechanism=#{mechanism}&authSource=foo" }
-
-          it 'does not allow a client to be created' do
-            expect {
-              new_local_client_nmio(string)
-            }.to raise_error(Mongo::Auth::InvalidConfiguration, /invalid auth source/)
-          end
-        end
-
-        context 'when mechanism_properties are provided' do
-          let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true" }
-
-          it 'sets the options on a client created with the uri' do
-            client = new_local_client_nmio(string)
-            expect(client.options[:auth_mech_properties]).to eq({ 'canonicalize_host_name' => true, 'service_name' => 'other' })
-          end
-        end
+        it_behaves_like 'a supported auth mechanism'
       end
 
       context 'scram-sha-1' do
         let(:mechanism) { 'SCRAM-SHA-1' }
         let(:expected) { :scram }
 
-        it 'sets the auth mechanism to :scram' do
-          expect(uri.uri_options[:auth_mech]).to eq(expected)
-        end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        it 'is case-insensitive' do
-          client = new_local_client_nmio(string.downcase)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        context 'when mechanism_properties are provided' do
-          let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=CANONICALIZE_HOST_NAME:true" }
-
-          it 'does not allow a client to be created' do
-            expect {
-              new_local_client_nmio(string)
-            }.to raise_error(Mongo::Auth::InvalidConfiguration, /mechanism_properties are not supported/)
-          end
-        end
+        it_behaves_like 'a supported auth mechanism'
       end
 
       context 'mongodb-x509' do
@@ -841,60 +755,7 @@ describe Mongo::URI do
         let(:expected)  { :mongodb_x509 }
         let(:credentials)  { user }
 
-        it 'sets the auth mechanism to :mongodb_x509' do
-          expect(uri.uri_options[:auth_mech]).to eq(expected)
-        end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        it 'is case-insensitive' do
-          client = new_local_client_nmio(string.downcase)
-          expect(client.options[:auth_mech]).to eq(expected)
-        end
-
-        context 'when auth source is invalid' do
-          let(:options) { "authMechanism=#{mechanism}&authSource=foo" }
-
-          it 'does not allow a client to be created' do
-            expect {
-              new_local_client_nmio(string)
-            }.to raise_error(Mongo::Auth::InvalidConfiguration, /invalid auth source/)
-          end
-        end
-
-        context 'when a username is not provided' do
-          let(:string) { "#{scheme}#{servers}/?#{options}" }
-
-          it 'recognizes the mechanism with no username' do
-            client = new_local_client_nmio(string.downcase)
-            expect(client.options[:auth_mech]).to eq(expected)
-            expect(client.options[:user]).to be_nil
-          end
-        end
-
-        context 'when a password is provided' do
-          let(:credentials) { "#{user}:#{password}"}
-          let(:password) { 's3kr4t' }
-
-          it 'does not allow a client to be created' do
-            expect {
-              new_local_client_nmio(string)
-            }.to raise_error(Mongo::Auth::InvalidConfiguration, /password is not supported/)
-          end
-        end
-
-        context 'when mechanism_properties are provided' do
-          let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=CANONICALIZE_HOST_NAME:true" }
-
-          it 'does not allow a client to be created' do
-            expect {
-              new_local_client_nmio(string)
-            }.to raise_error(Mongo::Auth::InvalidConfiguration, /mechanism_properties are not supported/)
-          end
-        end
+        it_behaves_like 'a supported auth mechanism'
       end
     end
 
@@ -908,12 +769,6 @@ describe Mongo::URI do
           expect(uri.credentials[:user]).to be_nil
           expect(uri.credentials[:password]).to be_nil
         end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:user]).to be_nil
-          expect(client.options[:password]).to be_nil
-        end
       end
 
       context 'with empty credentials' do
@@ -922,12 +777,6 @@ describe Mongo::URI do
         it 'sets user as an empty string and password as nil' do
           expect(uri.credentials[:user]).to eq('')
           expect(uri.credentials[:password]).to be_nil
-        end
-
-        it 'does not allow a client to be created with default auth mechanism' do
-          expect {
-            new_local_client_nmio(string)
-          }.to raise_error(Mongo::Auth::InvalidConfiguration, /empty username is not supported/)
         end
       end
     end


### PR DESCRIPTION
**This PR does not change client behavior**

This is part two of my work for [RUBY-1913](https://jira.mongodb.org/browse/RUBY-1913).

In this PR, I add integration tests for auth options in the client. These integration tests check that all authentication-related default options are set at the appropriate times. They also check that the same results are achieved whether the user is passing options through the URI or through the client options.

There are some tests that are commented out because they fail. There are some defaults that are not set when options are passed in through the client rather than the URI. In my next PR, I will update the client so that those tests pass. 